### PR TITLE
358: Conversation Summary Shows Private Message Instead of “No Conversations Exist” When No Interactions Backend

### DIFF
--- a/backend/src/generated/java/pom.xml
+++ b/backend/src/generated/java/pom.xml
@@ -126,7 +126,7 @@
         <spring-boot-version>2.7.17</spring-boot-version>
         <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <reactor-version>3.4.34</reactor-version>
-        <reactor-netty-version>1.2.8</reactor-netty-version>
+        <reactor-netty-version>1.0.39</reactor-netty-version>
         <junit-version>4.13.2</junit-version>
     </properties>
 </project>

--- a/backend/src/main/java/ch/uzh/ifi/imrg/platform/service/ConversationService.java
+++ b/backend/src/main/java/ch/uzh/ifi/imrg/platform/service/ConversationService.java
@@ -7,6 +7,7 @@ import ch.uzh.ifi.imrg.platform.rest.dto.output.ConversationSummaryOutputDTO;
 import ch.uzh.ifi.imrg.platform.utils.PatientAppAPIs;
 import jakarta.transaction.Transactional;
 import java.time.Instant;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -41,7 +42,14 @@ public class ConversationService {
       return dto;
 
     } catch (org.springframework.web.reactive.function.client.WebClientResponseException e) {
-      if (e.getStatusCode().is5xxServerError()) {
+
+      if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+        ConversationSummaryOutputDTO dto = new ConversationSummaryOutputDTO();
+        dto.setConversationSummary("");
+        return dto;
+      }
+
+      if (e.getStatusCode() == HttpStatus.FORBIDDEN) {
         throw new PrivateConversationException(
             "The conversation of the client with the chatbot is private.");
       }


### PR DESCRIPTION
-closes #358 